### PR TITLE
[refactor][#21] caching detail

### DIFF
--- a/DontForget.xcodeproj/project.pbxproj
+++ b/DontForget.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		AD3B45872B68C288009529DE /* AnniversaryContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3B45862B68C287009529DE /* AnniversaryContentView.swift */; };
 		AD3B458D2B68DE8F009529DE /* ConfirmView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD3B458C2B68DE8F009529DE /* ConfirmView.swift */; };
 		AD6097C62B7CD9C3005060A6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AD6097C52B7CD9C3005060A6 /* GoogleService-Info.plist */; };
+		AD7637612BA70887007552E1 /* CacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7637602BA70887007552E1 /* CacheManager.swift */; };
 		AD76D0622B594A5000EFB12E /* UIScreen+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD76D0612B594A5000EFB12E /* UIScreen+Extension.swift */; };
 		AD76D0642B594D2F00EFB12E /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD76D0632B594D2F00EFB12E /* Color+Extension.swift */; };
 		AD7BEBBC2B91E93B00A03753 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = AD7BEBB32B91E93A00A03753 /* Pretendard-Medium.otf */; };
@@ -160,6 +161,7 @@
 		AD3B45862B68C287009529DE /* AnniversaryContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnniversaryContentView.swift; sourceTree = "<group>"; };
 		AD3B458C2B68DE8F009529DE /* ConfirmView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmView.swift; sourceTree = "<group>"; };
 		AD6097C52B7CD9C3005060A6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		AD7637602BA70887007552E1 /* CacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheManager.swift; sourceTree = "<group>"; };
 		AD76D0612B594A5000EFB12E /* UIScreen+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Extension.swift"; sourceTree = "<group>"; };
 		AD76D0632B594D2F00EFB12E /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		AD7BEBB32B91E93A00A03753 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 		09642C342B649A750015220E /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				AD76375F2BA70845007552E1 /* Cache */,
 				09642C5F2B67D2D00015220E /* Error */,
 				09642C392B649B1D0015220E /* Network */,
 				09642C592B67CA160015220E /* Repository */,
@@ -498,6 +501,14 @@
 			path = Detail;
 			sourceTree = "<group>";
 		};
+		AD76375F2BA70845007552E1 /* Cache */ = {
+			isa = PBXGroup;
+			children = (
+				AD7637602BA70887007552E1 /* CacheManager.swift */,
+			);
+			path = Cache;
+			sourceTree = "<group>";
+		};
 		AD7BEBB22B91E92F00A03753 /* Pretendard */ = {
 			isa = PBXGroup;
 			children = (
@@ -747,6 +758,7 @@
 				AD147F212B57FF7500561846 /* String+Extension.swift in Sources */,
 				ADA2CC0E2B6CE4CC001A38D9 /* AnniversariesRepository.swift in Sources */,
 				09642C612B67D2DC0015220E /* ErrorResponse.swift in Sources */,
+				AD7637612BA70887007552E1 /* CacheManager.swift in Sources */,
 				09642C4A2B64A37A0015220E /* AnniversaryService.swift in Sources */,
 				09642C532B67C76F0015220E /* CreationUseCase.swift in Sources */,
 				ADAFFDD52B70C8CC00746D3E /* FetchAnniversaryDetailUseCase.swift in Sources */,

--- a/DontForget/Sources/Data/Cache/CacheManager.swift
+++ b/DontForget/Sources/Data/Cache/CacheManager.swift
@@ -1,0 +1,35 @@
+//
+//  CacheManager.swift
+//  DontForget
+//
+//  Created by 제나 on 3/17/24.
+//
+
+import Foundation
+
+final class CacheManager {
+    static let shared = CacheManager()
+    private let cacheDetails = NSCache<NSString, AnniversaryDetail>()
+    
+    init() {
+        cacheDetails.countLimit = 20
+    }
+    
+    func loadDetail(_ anniversaryId: Int) -> AnniversaryDetail? {
+        let key = NSString(string: "\(anniversaryId)")
+        if let cached = cacheDetails.object(forKey: key) {
+            return cached
+        }
+        return nil
+    }
+    
+    func setDetail(_ detail: AnniversaryDetail) {
+        let key = NSString(string: "\(detail.dto.anniversaryId)")
+        cacheDetails.setObject(detail, forKey: key)
+    }
+    
+    func removeDetail(_ anniversaryId: Int) {
+        let key = NSString(string: "\(anniversaryId)")
+        cacheDetails.removeObject(forKey: key)
+    }
+}

--- a/DontForget/Sources/Data/DTO/DTO.swift
+++ b/DontForget/Sources/Data/DTO/DTO.swift
@@ -77,3 +77,10 @@ struct AnniversaryDetailDTO: Decodable {
     let baseDate: String
     let baseType: String
 }
+
+class AnniversaryDetail {
+    let dto: AnniversaryDetailDTO
+    init(anniversaryDetailDTO: AnniversaryDetailDTO) {
+        self.dto = anniversaryDetailDTO
+    }
+}

--- a/DontForget/Sources/Data/Network/NetworkMonitor.swift
+++ b/DontForget/Sources/Data/Network/NetworkMonitor.swift
@@ -8,7 +8,6 @@
 import Foundation
 import Network
 
-@Observable
 final class NetworkMonitor: ObservableObject {
     static let shared = NetworkMonitor()
     private let networkMonitor = NWPathMonitor()

--- a/DontForget/Sources/Data/Service/AnniversaryService.swift
+++ b/DontForget/Sources/Data/Service/AnniversaryService.swift
@@ -85,7 +85,6 @@ class AnniversaryService {
     
     func fetchAnniversaryDetail(anniversaryId: Int) async throws -> AnniversaryDetailResponse {
         return try await withCheckedThrowingContinuation { continuation in
-            print("=== DEBUG: fetch detail \(anniversaryId)")
             provider.request(.readAnniversary(anniversaryId: anniversaryId)) { result in
                 switch result {
                 case let .success(response):

--- a/DontForget/Sources/Presentations/Application/Common/ConfirmView.swift
+++ b/DontForget/Sources/Presentations/Application/Common/ConfirmView.swift
@@ -82,7 +82,7 @@ struct ConfirmView: View {
         ZStack {
             Color.black.opacity(0.4)
             VStack {
-                Image(.anniversaryDelete)
+                Image(.calendarDeleteIcon)
                     .resizable()
                     .frame(width: 56, height: 56)
                     .padding(.top, 32)

--- a/DontForget/Sources/Presentations/Application/Creation/CreationViewModel.swift
+++ b/DontForget/Sources/Presentations/Application/Creation/CreationViewModel.swift
@@ -105,10 +105,10 @@ final class CreationViewModel: ViewModelType {
         }
         .receive(on: DispatchQueue.main)
         .sink { completion in
+            CacheManager.shared.removeDetail(id)
             self.dismiss = true
             if case let .failure(error) = completion {
                 self.errorMessage = error.localizedDescription
-                print("=== \(String(describing: self.errorMessage))")
             }
         } receiveValue: { response in
             self.creationResponse = response
@@ -130,7 +130,6 @@ final class CreationViewModel: ViewModelType {
                     )
                     promise(.success(response))
                 } catch {
-                    print("=== DEBUG: \(error)")
                     promise(.failure(error))
                     self.state = .failed("failed fetchAnniversaryDetail()")
                 }

--- a/DontForget/Sources/Presentations/Application/Home/ViewModel/HomeViewModel.swift
+++ b/DontForget/Sources/Presentations/Application/Home/ViewModel/HomeViewModel.swift
@@ -82,7 +82,6 @@ final class DefaultHomeViewModel: ViewModelType {
         .sink { _ in } receiveValue: { [weak self] response in
             if let self = self, let response = response {
                 self.anniversaries = response.anniversaries.sorted(by: { $0.solarDate < $1.solarDate })
-                print("=== DEBUG: \(self.anniversaries)")
                 self.state = .success
                 if !self.anniversaries.isEmpty {
                     self.fetchFirstAnniversaryDetail()
@@ -137,7 +136,6 @@ final class DefaultHomeViewModel: ViewModelType {
                         }
                     }
                     let response = try await AnniversaryService.shared.changePushState(status: status)
-                    print("=== DEBUG: changeStatus \(status)")
                     promise(.success(response))
                 } catch {
                     print("=== DEBUG: changeStatus \(error)")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

> 상세정보 조회 뷰가 onAppear할 때마다 detail 요청, 편집 시작할때, 취소하고 나갈때, 편집 내용 저장할 때 전부 요청하고 있었음.
> 처음 조회할 때만 서버에 detail 요청 → 받은 데이터를 메모리 캐시에 담음
> 이후 조회할 때, 편집 취소하고 나갈 때 → 메모리 캐시에 담긴 놈 띄움
> 편집 내용 저장할 때 → 메모리 캐시에 담긴 기존 데이터 삭제하고 다시 요청

## 참고
> [블로그에 과정담아둠! 참고](https://ios-moon.tistory.com/30)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요
> 추가로 중복 코드 삭제 + 없는 리소스 이름 사용 부분 수정 완